### PR TITLE
Calibration patch for newer AHT20's

### DIFF
--- a/adafruit_ahtx0.py
+++ b/adafruit_ahtx0.py
@@ -108,18 +108,18 @@ class AHTx0:
     def calibrate(self) -> bool:
         """Ask the sensor to self-calibrate. Returns True on success, False otherwise"""
         # Newer AHT20's may not succeed, so wrapping in try/except
-        try:
-            self._buf[0] = AHTX0_CMD_CALIBRATE
-            self._buf[1] = 0x08
-            self._buf[2] = 0x00
-            with self.i2c_device as i2c:
+        self._buf[0] = AHTX0_CMD_CALIBRATE
+        self._buf[1] = 0x08
+        self._buf[2] = 0x00
+        with self.i2c_device as i2c:
+            try:
                 i2c.write(self._buf, start=0, end=3)
-            while self.status & AHTX0_STATUS_BUSY:
-                time.sleep(0.01)
-            if not self.status & AHTX0_STATUS_CALIBRATED:
-                return False
-        except Exception:  # pylint: disable=broad-except
-            pass
+            except Exception:  # pylint: disable=broad-except
+                pass
+        while self.status & AHTX0_STATUS_BUSY:
+            time.sleep(0.01)
+        if not self.status & AHTX0_STATUS_CALIBRATED:
+            return False
         return True
 
     @property

--- a/adafruit_ahtx0.py
+++ b/adafruit_ahtx0.py
@@ -106,7 +106,7 @@ class AHTx0:
         time.sleep(0.02)  # 20ms delay to wake up
 
     def calibrate(self) -> bool:
-        """Ask the sensor to self-calibrate. Returns True on success, False otherwise"""
+        """Ask the sensor to self-calibrate. May not 'succeed' on newer AHT20s."""
         self._buf[0] = AHTX0_CMD_CALIBRATE
         self._buf[1] = 0x08
         self._buf[2] = 0x00
@@ -114,8 +114,6 @@ class AHTx0:
             i2c.write(self._buf, start=0, end=3)
         while self.status & AHTX0_STATUS_BUSY:
             time.sleep(0.01)
-        if not self.status & AHTX0_STATUS_CALIBRATED:
-            return False
         return True
 
     @property

--- a/adafruit_ahtx0.py
+++ b/adafruit_ahtx0.py
@@ -106,15 +106,21 @@ class AHTx0:
         time.sleep(0.02)  # 20ms delay to wake up
 
     def calibrate(self) -> bool:
-        """Ask the sensor to self-calibrate. May not 'succeed' on newer AHT20s."""
-        self._buf[0] = AHTX0_CMD_CALIBRATE
-        self._buf[1] = 0x08
-        self._buf[2] = 0x00
-        with self.i2c_device as i2c:
-            i2c.write(self._buf, start=0, end=3)
-        while self.status & AHTX0_STATUS_BUSY:
-            time.sleep(0.01)
-        return True
+        """Ask the sensor to self-calibrate. Returns True on success, False otherwise"""
+        """Newer AHT20's may not succeed, so wrapping in try/except"""
+        try:
+            self._buf[0] = AHTX0_CMD_CALIBRATE
+            self._buf[1] = 0x08
+            self._buf[2] = 0x00
+            with self.i2c_device as i2c:
+                i2c.write(self._buf, start=0, end=3)
+            while self.status & AHTX0_STATUS_BUSY:
+                time.sleep(0.01)
+            if not self.status & AHTX0_STATUS_CALIBRATED:
+                return False
+            return True
+        except:
+            pass
 
     @property
     def status(self) -> int:

--- a/adafruit_ahtx0.py
+++ b/adafruit_ahtx0.py
@@ -107,7 +107,7 @@ class AHTx0:
 
     def calibrate(self) -> bool:
         """Ask the sensor to self-calibrate. Returns True on success, False otherwise"""
-        """Newer AHT20's may not succeed, so wrapping in try/except"""
+        # Newer AHT20's may not succeed, so wrapping in try/except
         try:
             self._buf[0] = AHTX0_CMD_CALIBRATE
             self._buf[1] = 0x08
@@ -118,9 +118,9 @@ class AHTx0:
                 time.sleep(0.01)
             if not self.status & AHTX0_STATUS_CALIBRATED:
                 return False
-            return True
-        except:
+        except Exception:  # pylint: disable=broad-except
             pass
+        return True
 
     @property
     def status(self) -> int:


### PR DESCRIPTION
Updating calibration function so that it isn't required to pass for newer AHT20's. This same change was made for the [Arduino library](https://github.com/adafruit/Adafruit_AHTX0/pull/13)