### PR TITLE
Retry Calibration with AHT20 command on failure

### DIFF
--- a/adafruit_ahtx0.py
+++ b/adafruit_ahtx0.py
@@ -116,17 +116,18 @@ class AHTx0:
             try:
                 # Newer AHT20's may not succeed with old command, so wrapping in try/except
                 i2c.write(self._buf, start=0, end=3)
-            except Exception:  # pylint: disable=broad-except
+            except (RuntimeError, OSError):
                 calibration_failed = True
 
         if calibration_failed:
             # try another calibration command for newer AHT20's
+            # print("Calibration failed, trying AH20 command")
             time.sleep(0.01)
             self._buf[0] = AHT20_CMD_CALIBRATE
             with self.i2c_device as i2c:
                 try:
                     i2c.write(self._buf, start=0, end=3)
-                except Exception:
+                except (RuntimeError, OSError):
                     pass
 
         while self.status & AHTX0_STATUS_BUSY:


### PR DESCRIPTION
If try-except around legacy calibrate command fails, try to send new one instead afterwards.

Addressing #17 and possibly #18 as well
Moved try-except from PR #16 doesn't work with the latest AHT20s (at least the ones I have) but instead gives very cryptic OS error implying the device is not present. Found different first-byte to write for newer AHT20's and tried that (details in #17 ). Made updates that I think will work with AHT10 still as the execution path remains unchanged from before, but retries if that fails. 

Tested on my setup (details in #17) and works great (takes the `calibration_failed` path, then calibrates and succeeds).